### PR TITLE
Add link to the GitHub Actions workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # libyara-wasm
-![](https://github.com/mattnotmitt/libyara-wasm/workflows/Build%20%26%20Deploy/badge.svg)
+[![Build Status](https://github.com/mattnotmitt/libyara-wasm/workflows/Build%20%26%20Deploy/badge.svg)](https://github.com/mattnotmitt/libyara-wasm/actions?workflow=Build%20%26%20Deploy)
+
 WASM-based JS Library using a c++ wrapper around [libyara](https://github.com/virustotal/yara). Currently only exposes methods required by [CyberChef](https://github.com/gchq/CyberChef) but may potentially expose more in the future. No documentation at the moment.
 ## Build
 


### PR DESCRIPTION
This PR correctly links the GitHub Actions badge and also adds a missing newline.